### PR TITLE
Switching to modular imports to prevent Xcode from complaining...

### DIFF
--- a/Pod/Classes/KWExample+KIFTester.h
+++ b/Pod/Classes/KWExample+KIFTester.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014 Indiegogo Inc. All rights reserved.
 //
 
-#import <Kiwi/Kiwi.h>
-#import <KIF/KIF.h>
+@import Kiwi;
+@import KIF;
 
 #ifdef KIFActorWithClass
 #undef KIFActorWithClass


### PR DESCRIPTION
...when using KIF-Kiwi as a framework.

What happens now when importing KIF-Kiwi as a module is that, even though it builds, Xcode reports the following "Parse issue":
![screen shot 2016-07-07 at 14 45 40](https://cloud.githubusercontent.com/assets/9800173/16655316/a55747d4-4451-11e6-9792-d3a18f1d278d.png)
This, besides being visually displeasing, also precludes proper syntax highlighting and code completion in the file.
Comments are welcome.