### PR TITLE
Update Kiwi version to 3.0 on pod spec

### DIFF
--- a/KIF-Kiwi.podspec
+++ b/KIF-Kiwi.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes'
-  s.dependency 'Kiwi', '~> 2.0'
+  s.dependency 'Kiwi', '~> 3.0'
   s.dependency 'KIF', '~> 3.0'
   s.framework = 'XCTest'
 end


### PR DESCRIPTION
Since [Kiwi 3.0](https://github.com/kiwi-bdd/Kiwi/releases/tag/v3.0.0) has been released, it is necessary to bump the dependency version on KIF-Kiwi's podspec, in order to use KIF-Kiwi with the latest version of Kiwi.